### PR TITLE
Sentries don't require batteries to fire

### DIFF
--- a/source/lua/CPPSentry.lua
+++ b/source/lua/CPPSentry.lua
@@ -1,0 +1,8 @@
+if Server then
+    -- combat doesn't have batteries but we still want sentries to work
+    local function UpdateBatteryState(self)
+        self.attachedToBattery = true
+    end
+
+    ReplaceLocals(Sentry.OnUpdate, {UpdateBatteryState = UpdateBatteryState})
+end

--- a/source/lua/CPPShared.lua
+++ b/source/lua/CPPShared.lua
@@ -15,3 +15,4 @@ end
 Script.Load("lua/CPPUtilities.lua")
 Script.Load("lua/MarinePersistData.lua")
 Script.Load("lua/CPPMarineSpawn.lua")
+Script.Load("lua/CPPSentry.lua")


### PR DESCRIPTION
Sentries will now fire even without a battery nearby. Fixes #8.

- The new file is loaded as Shared, even though I only touch server stuff. The original file is loaded on both, so it's possible you may want to load changes on both in the future. If not, you can change it to load the file as Server, and remove the `if Server` check.