### PR TITLE
Keep command structures closed at all times

### DIFF
--- a/source/lua/CPPCommandStructure_Server.lua
+++ b/source/lua/CPPCommandStructure_Server.lua
@@ -8,6 +8,23 @@
  *  from 'using' the CommandStructure.
 ]]
 
+local function CheckForLogin(self)
+    return false
+end
+
+local oldOnInit = CommandStructure.OnInitialized
+
+function CommandStructure:OnInitialized()
+    -- Replace the callback that checks if the structure should open or close
+    -- Callbacks that return false get removed
+    ReplaceLocals(oldOnInit, {CheckForLogin = CheckForLogin})
+
+    oldOnInit(self)
+
+    self.occupied = true
+    self.loginAllowed = false
+end
+
 function CommandStructure:OnUse(player, elapsedTime, useSuccessTable)
 
 end


### PR DESCRIPTION
Command station and hive will now be "occupied" and therefore in their
visibly closed state. Fixes #12.

You can maybe remove some of the login overrides in CPPCommandStructure.lua and CPPCommandStructure_Server.lua. Or maybe not. I didn't check.