### PR TITLE
Prevent marines from ejecting from exosuits

### DIFF
--- a/source/lua/CPPExo.lua
+++ b/source/lua/CPPExo.lua
@@ -1,0 +1,3 @@
+function Exo:GetCanEject()
+    return false
+end

--- a/source/lua/CPPFileHooks.lua
+++ b/source/lua/CPPFileHooks.lua
@@ -21,6 +21,7 @@ ModLoader.SetupFileHook( "lua/Player_Client.lua", "lua/CPPPlayer_Client.lua", "p
 ModLoader.SetupFileHook( "lua/Marine.lua", "lua/CPPMarine.lua", "post" )
 ModLoader.SetupFileHook( "lua/Marine_Client.lua", "lua/CPPMarine_Client.lua", "post" )
 ModLoader.SetupFileHook( "lua/Marine_Server.lua", "lua/CPPMarine_Server.lua", "post" )
+ModLoader.SetupFileHook( "lua/Exo.lua", "lua/CPPExo.lua", "post" )
 ModLoader.SetupFileHook( "lua/Alien_Client.lua", "lua/CPPAlien_Client.lua", "post" )
 ModLoader.SetupFileHook( "lua/MarineActionFinderMixin.lua", "lua/CPPMarineActionFinderMixin.lua", "post" )
 ModLoader.SetupFileHook( "lua/Hud/Marine/GUIMarineHUD.lua", "lua/CPPGUIMarineHud.lua", "post" )


### PR DESCRIPTION
This is as simple as possible, and doesn't remove any associated
game logic that is unnecessary if marines can't eject. For example,
GUIExoEject still updates every frame.

Fixes #19 