### PR TITLE
Grant XP to players when their nearby teammate gets a kill

### DIFF
--- a/source/lua/CPPBalance.lua
+++ b/source/lua/CPPBalance.lua
@@ -53,6 +53,12 @@ kStartPoints = 1
 -- the modifier applied to the 'BaseXpOnKill' to determine how much xp for assists
 kXPAssistModifier = 0.33
 
+-- The fraction of 'BaseXpOnKill' given for being near a kill and doing no damage
+kNearbyKillXPModifier = 0.25
+
+-- Kills within this distance to a player will grant xp
+kNearbyKillXPDistance = 20
+
 -- upper bound for modifier used to scale xp based on distance to enemy tech point
 kDistanceXPModifierMaxUpperBound = 2
 

--- a/source/lua/CPPGUINotifications.lua
+++ b/source/lua/CPPGUINotifications.lua
@@ -15,7 +15,14 @@ GUINotifications.kScoreDisplayMinFontHeightDmg = 40
 
 GUINotifications.kTimeToDisplayFinalAccumulatedValue = 2
 
-local kResetSourceTypes = { [kXPSourceType.Kill] = true, [kXPSourceType.Assist] = true, [kXPSourceType.Build] = true }
+local kResetSourceTypes =
+{
+    [kXPSourceType.Kill] = true,
+    [kXPSourceType.Assist] = true,
+    [kXPSourceType.Nearby] = true,
+    [kXPSourceType.Build] = true,
+}
+
 local kAccumulatingSourceTypes = { [kXPSourceType.Weld] = true, [kXPSourceType.Heal] = true }
 
 local ns2_GUINotifications_Initialize = GUINotifications.Initialize
@@ -170,6 +177,9 @@ function GUINotifications:UpdateCombatScoreDisplay(deltaTime)
             elseif source == kXPSourceType.Assist then
                 self.scoreDisplay:SetColor(GUINotifications.kScoreDisplayPrimaryTextColor)
                 self.scoreDisplay:SetText(string.format("Assist +%s XP", self.xpSinceReset))
+            elseif source == kXPSourceType.Nearby then
+                self.scoreDisplay:SetColor(GUINotifications.kScoreDisplayPrimaryTextColor)
+                self.scoreDisplay:SetText(string.format("Nearby Kill +%s XP", self.xpSinceReset))
             end
 
             self.scoreDisplay:SetScale(GUIScale(Vector(0.7, 0.7, 0.7)))

--- a/source/lua/CPPGlobals.lua
+++ b/source/lua/CPPGlobals.lua
@@ -16,6 +16,7 @@ kXPSourceType = enum(
     "Kill",
     "Assist",
     "Damage",
+    "Nearby",
     "Build",
     "Weld",
     "Heal"

--- a/source/lua/CPPPointGiverMixin.lua
+++ b/source/lua/CPPPointGiverMixin.lua
@@ -101,6 +101,16 @@ if Server then
 
             end
 
+            local playersNearby = GetEntitiesForTeamWithinRange("Player", attacker:GetTeamNumber(), self:GetOrigin(), kNearbyKillXPDistance)
+
+            for _, player in ipairs(playersNearby) do
+
+                if player:GetIsAlive() and player ~= attacker then
+                    player:AddCombatNearbyKill(self:GetCombatRank())
+                end
+
+            end
+
             self:GetTeam():AddTeamResources(kKillTeamReward)
 
         end

--- a/source/lua/CombatScoreMixin.lua
+++ b/source/lua/CombatScoreMixin.lua
@@ -184,6 +184,17 @@ function CombatScoreMixin:AddCombatAssistKill(victimRank)
 
 end
 
+function CombatScoreMixin:AddCombatNearbyKill(victimRank)
+    if GetGameInfoEntity():GetWarmUpActive() then return end
+
+    if not self.combatXP then
+        self.combatXP = 0
+    end
+
+    local xp = CombatPlusPlus_GetBaseKillXP(victimRank) * kNearbyKillXPModifier
+    self:AddXP(xp, kXPSourceType.Kill, Entity.invalidId)
+end
+
 function CombatScoreMixin:AddCombatDamage(damage)
 
     if GetGameInfoEntity():GetWarmUpActive() then return end

--- a/source/lua/CombatScoreMixin.lua
+++ b/source/lua/CombatScoreMixin.lua
@@ -192,7 +192,7 @@ function CombatScoreMixin:AddCombatNearbyKill(victimRank)
     end
 
     local xp = CombatPlusPlus_GetBaseKillXP(victimRank) * kNearbyKillXPModifier
-    self:AddXP(xp, kXPSourceType.Kill, Entity.invalidId)
+    self:AddXP(xp, kXPSourceType.Nearby, Entity.invalidId)
 end
 
 function CombatScoreMixin:AddCombatDamage(damage)


### PR DESCRIPTION
When a player kills an enemy player, all teammates of the killer
within `kNearbyKillXPDistance` will receive some XP, determined by
`kNearbyKillXPModifier`. The killer does not receive this XP.

Adds the above two constants to CPPBalance.lua.
Adds `CombatScoreMixin.AddCombatAssistKill`

~~Note that `kXPSourceType` is still `Kill` for these nearby kills.~~
Adds a new source of XP, `kXPSourceType.Nearby`.

Fixes #22 